### PR TITLE
fix(security): replace vulnerable decompress package

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -6,14 +6,18 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   audit:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -24,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap
@@ -35,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bootstrap
         uses: ./.github/actions/bootstrap

--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "deploy:arbitrum": "source .subgraph-version && source .env && graph deploy --studio --deploy-key $GRAPH_STUDIO_TOKEN --version-label $SUBGRAPH_VERSION token-holders-arbitrum subgraph-arbitrum.yaml",
     "test": "graph test --version 0.5.3",
     "test:force": "yarn test --recompile",
-    "auth": "source .env && graph auth --product hosted-service $GRAPH_TOKEN",
-    "preinstall": "npx only-allow@1.2.2 pnpm"
+    "auth": "source .env && graph auth --product hosted-service $GRAPH_TOKEN"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "^0.98.1",
@@ -35,9 +34,9 @@
   },
   "engines": {
     "node": ">=24",
-    "pnpm": ">=10.33.0",
+    "pnpm": ">=11.13.0",
     "npm": "use-pnpm",
     "yarn": "use-pnpm"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.13.0"
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Jem <0x0xjem@gmail.com>",
   "license": "MIT",
   "scripts": {
+    "preinstall": "node -e \"if (!process.env.npm_config_user_agent?.startsWith('pnpm/')) { console.error('Use pnpm'); process.exit(1) }\"",
     "codegen": "graph codegen && yarn eslint --config ./.eslintrc.json --fix generated/",
     "build": "graph build",
     "lint": "prettier --write . && eslint --config ./.eslintrc.json --fix src generated",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "author": "Jem <0x0xjem@gmail.com>",
   "license": "MIT",
   "scripts": {
-    "preinstall": "node -e \"if (!process.env.npm_config_user_agent?.startsWith('pnpm/')) { console.error('Use pnpm'); process.exit(1) }\"",
     "codegen": "graph codegen && yarn eslint --config ./.eslintrc.json --fix generated/",
     "build": "graph build",
     "lint": "prettier --write . && eslint --config ./.eslintrc.json --fix src generated",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ overrides:
   brace-expansion@<2.0.3: ^2.0.3
   braces@<3.0.3: ^3.0.3
   cross-spawn@<7.0.5: ^7.0.5
-  decompress@<=4.2.1: npm:@xhmikosr/decompress@^11.1.3
+  "@graphprotocol/graph-cli>decompress@<=4.2.1": npm:@xhmikosr/decompress@^11.1.3
   ejs@<3.1.10: ^3.1.10
   flatted@<3.4.2: ^3.4.2
   follow-redirects@<1.16.0: ^1.16.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   ajv@<6.14.0: ^6.14.0
-  axios@<1.15.2: ^1.15.2
-  brace-expansion@<2.0.3: ^2.0.3
+  axios@<1.18.0: ^1.18.0
+  brace-expansion@<2.1.2: ^2.1.2
   braces@<3.0.3: ^3.0.3
   cross-spawn@<7.0.5: ^7.0.5
   "@graphprotocol/graph-cli>decompress@<=4.2.1": npm:@xhmikosr/decompress@^11.1.3
@@ -16,7 +16,7 @@ overrides:
   follow-redirects@<1.16.0: ^1.16.0
   form-data@>=4.0.0 <4.0.6: ^4.0.6
   glob@<11.1.0: ^11.1.0
-  immutable@<5.1.5: ^5.1.5
+  immutable@<5.1.8: ^5.1.8
   js-yaml@<=4.1.1: ^4.2.0
   lodash.trim@<4.18.0: 4.18.0
   lodash.trimend@<4.18.0: 4.18.0
@@ -818,6 +818,13 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==,
+      }
+    engines: { node: ">= 6.0.0" }
+
   ajv@6.14.0:
     resolution:
       {
@@ -944,10 +951,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  axios@1.16.0:
+  axios@1.18.1:
     resolution:
       {
-        integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==,
+        integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==,
       }
 
   b4a@1.8.1:
@@ -1011,10 +1018,10 @@ packages:
         integrity: sha512-I39vO57y+LBEIcAV7fif0sn96fYOYVqrPiOD+53MxQGv4DBgt1/HHZh0BHheWx2hVe24q5LTSXxqeV1Y3Nzkgg==,
       }
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     resolution:
       {
-        integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
+        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
       }
 
   brace-expansion@5.0.7:
@@ -1937,13 +1944,6 @@ packages:
         integrity: sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==,
       }
 
-  hasown@2.0.2:
-    resolution:
-      {
-        integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==,
-      }
-    engines: { node: ">= 0.4" }
-
   hasown@2.0.4:
     resolution:
       {
@@ -1957,6 +1957,13 @@ packages:
         integrity: sha512-ahwimsC23ICE4kPl9xTBjKB4inbRaeLyZeRunC/1Jy/Z6X8tv22MEAjK+KBOMSVLaqXPTTmd8638waVIKLGx2w==,
       }
     engines: { node: ">=8.0.0" }
+
+  https-proxy-agent@5.0.1:
+    resolution:
+      {
+        integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==,
+      }
+    engines: { node: ">= 6" }
 
   human-signals@2.1.0:
     resolution:
@@ -1992,10 +1999,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  immutable@5.1.5:
+  immutable@5.1.9:
     resolution:
       {
-        integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==,
+        integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==,
       }
 
   import-fresh@3.3.0:
@@ -3660,7 +3667,7 @@ snapshots:
       glob: 11.1.0
       gluegun: 5.2.0(debug@4.4.3(supports-color@8.1.1))
       graphql: 16.11.0
-      immutable: 5.1.5
+      immutable: 5.1.9
       jayson: 4.2.0
       js-yaml: 4.3.0
       kubo-rpc-client: 5.4.1(undici@7.28.0)
@@ -4239,6 +4246,12 @@ snapshots:
 
   acorn@8.8.2: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -4270,9 +4283,10 @@ snapshots:
 
   apisauce@2.1.6(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
+      axios: 1.18.1(debug@4.4.3(supports-color@8.1.1))
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   app-module-path@2.2.0: {}
 
@@ -4301,13 +4315,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+  axios@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -4327,7 +4343,7 @@ snapshots:
     dependencies:
       browser-readablestream-to-it: 2.0.10
 
-  brace-expansion@2.1.0:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
@@ -4554,7 +4570,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es6-promise@4.2.8: {}
 
@@ -4803,7 +4819,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-iterator@1.0.2: {}
@@ -4886,6 +4902,7 @@ snapshots:
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - debug
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -4917,10 +4934,6 @@ snapshots:
 
   hashlru@2.3.0: {}
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
@@ -4933,6 +4946,13 @@ snapshots:
       is-stream: 2.0.1
       parse-json: 4.0.0
       tunnel-agent: 0.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -4950,7 +4970,7 @@ snapshots:
 
   ignore@5.2.0: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.0:
     dependencies:
@@ -5029,7 +5049,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-retry-allowed@1.2.0: {}
 
@@ -5273,11 +5293,11 @@ snapshots:
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 2.1.2
 
   minipass@7.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   brace-expansion@<2.0.3: ^2.0.3
   braces@<3.0.3: ^3.0.3
   cross-spawn@<7.0.5: ^7.0.5
+  decompress@<=4.2.1: npm:@xhmikosr/decompress@^11.1.3
   ejs@<3.1.10: ^3.1.10
   flatted@<3.4.2: ^3.4.2
   follow-redirects@<1.16.0: ^1.16.0
@@ -27,7 +28,7 @@ overrides:
   picomatch@<2.3.2: ^2.3.2
   semver@<7.5.2: ^7.5.2
   tmp@<0.2.6: ^0.2.6
-  undici@<7.24.0: ^7.24.0
+  undici@>=7.0.0 <7.28.0: ^7.28.0
   uuid@<11.1.1: ^11.1.1
   ws@>=7.0.0 <7.5.11: ^7.5.11
   word-wrap@<1.2.4: ^1.2.4
@@ -38,7 +39,7 @@ importers:
     dependencies:
       "@graphprotocol/graph-cli":
         specifier: ^0.98.1
-        version: 0.98.1(@types/node@20.1.1)(typescript@4.7.4)(zod@3.25.76)
+        version: 0.98.1(@types/node@20.1.1)(supports-color@8.1.1)(typescript@4.7.4)(zod@3.25.76)
       "@graphprotocol/graph-ts":
         specifier: ^0.30.0
         version: 0.30.0
@@ -92,6 +93,12 @@ packages:
         integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==,
       }
     engines: { node: ">=6.9.0" }
+
+  "@borewit/text-codec@0.2.2":
+    resolution:
+      {
+        integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==,
+      }
 
   "@chainsafe/is-ip@2.1.0":
     resolution:
@@ -577,6 +584,25 @@ packages:
         integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==,
       }
 
+  "@sec-ant/readable-stream@0.4.1":
+    resolution:
+      {
+        integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==,
+      }
+
+  "@tokenizer/inflate@0.4.1":
+    resolution:
+      {
+        integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==,
+      }
+    engines: { node: ">=18" }
+
+  "@tokenizer/token@0.3.0":
+    resolution:
+      {
+        integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==,
+      }
+
   "@types/connect@3.4.35":
     resolution:
       {
@@ -722,6 +748,41 @@ packages:
         integrity: sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA==,
       }
     engines: { node: ">=16.0.0" }
+
+  "@xhmikosr/decompress-tar@9.0.1":
+    resolution:
+      {
+        integrity: sha512-4AkVR1SoqTxYY22IRRYKDeLirPIDGqMqYsqgjKYuwhgRcBb+yDP4t5Xph33UCzL/nahK/aADmlMEjTNstbX7kw==,
+      }
+    engines: { node: ">=20" }
+
+  "@xhmikosr/decompress-tarbz2@9.0.2":
+    resolution:
+      {
+        integrity: sha512-m0DvZhE7remCxtS8xY2iHSjivT4v+iyYDdfNoeuu8Nm+7g8xEXdLKSyDEicu4u1ImJLLGEfjMuTLera/F6UGWw==,
+      }
+    engines: { node: ">=20" }
+
+  "@xhmikosr/decompress-targz@9.0.1":
+    resolution:
+      {
+        integrity: sha512-1JXu2b6yrpm5EuBoOzMU57B4qrHXJKWQQ7LlMynNEiz85mEjDciO3ayf//GXaTLLCEKiHjWlU3q3THjgf7uODA==,
+      }
+    engines: { node: ">=20" }
+
+  "@xhmikosr/decompress-unzip@8.2.1":
+    resolution:
+      {
+        integrity: sha512-2MS94QnmXQwjkKN8WyFiu1sU7J3rcWJcMze4kRYsX7tN+CXpUGECgkh4YSOhujpkWPuVlFudIziJHO/TxOqkQQ==,
+      }
+    engines: { node: ">=20" }
+
+  "@xhmikosr/decompress@11.1.3":
+    resolution:
+      {
+        integrity: sha512-NiyhJq6z7ERsYghcnXZUI6ooDXgZtoB+G9eUsYhfSM4VLp2rKx9UxhKI1NEf1PqosrNPxG3bnSsr2UBVbNurlg==,
+      }
+    engines: { node: ">=20" }
 
   abitype@0.7.1:
     resolution:
@@ -889,6 +950,17 @@ packages:
         integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==,
       }
 
+  b4a@1.8.1:
+    resolution:
+      {
+        integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==,
+      }
+    peerDependencies:
+      react-native-b4a: "*"
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution:
       {
@@ -901,6 +973,17 @@ packages:
         integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==,
       }
     engines: { node: 18 || 20 || >=22 }
+
+  bare-events@2.9.1:
+    resolution:
+      {
+        integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==,
+      }
+    peerDependencies:
+      bare-abort-controller: "*"
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base64-js@1.5.1:
     resolution:
@@ -922,12 +1005,6 @@ packages:
       }
     hasBin: true
 
-  bl@1.2.3:
-    resolution:
-      {
-        integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==,
-      }
-
   blob-to-it@2.0.10:
     resolution:
       {
@@ -940,10 +1017,10 @@ packages:
         integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==,
       }
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     resolution:
       {
-        integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==,
+        integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -958,30 +1035,6 @@ packages:
     resolution:
       {
         integrity: sha512-I/9hEcRtjct8CzD9sVo9Mm4ntn0D+7tOVrjbPl69XAoOfgJ8NBdOQU+WX+5SHhcELJDb14mWt7zuvyqha+MEAQ==,
-      }
-
-  buffer-alloc-unsafe@1.1.0:
-    resolution:
-      {
-        integrity: sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==,
-      }
-
-  buffer-alloc@1.2.0:
-    resolution:
-      {
-        integrity: sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==,
-      }
-
-  buffer-crc32@0.2.13:
-    resolution:
-      {
-        integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
-      }
-
-  buffer-fill@1.0.0:
-    resolution:
-      {
-        integrity: sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==,
       }
 
   buffer-from@1.1.2:
@@ -1158,6 +1211,13 @@ packages:
         integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
       }
 
+  commander@6.2.1:
+    resolution:
+      {
+        integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==,
+      }
+    engines: { node: ">= 6" }
+
   config-chain@1.1.13:
     resolution:
       {
@@ -1170,12 +1230,6 @@ packages:
         integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==,
       }
     engines: { node: ">= 0.6" }
-
-  core-util-is@1.0.3:
-    resolution:
-      {
-        integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==,
-      }
 
   cosmiconfig@7.0.1:
     resolution:
@@ -1220,41 +1274,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decompress-tar@4.1.1:
-    resolution:
-      {
-        integrity: sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==,
-      }
-    engines: { node: ">=4" }
-
-  decompress-tarbz2@4.1.1:
-    resolution:
-      {
-        integrity: sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==,
-      }
-    engines: { node: ">=4" }
-
-  decompress-targz@4.1.1:
-    resolution:
-      {
-        integrity: sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==,
-      }
-    engines: { node: ">=4" }
-
-  decompress-unzip@4.0.1:
-    resolution:
-      {
-        integrity: sha512-1fqeluvxgnn86MOh66u8FjbtJpAFv5wgCT9Iw8rcBqQcCo5tO8eiJw7NNTrvt9n4CRBVq7CstiS922oPgyGLrw==,
-      }
-    engines: { node: ">=4" }
-
-  decompress@4.2.1:
-    resolution:
-      {
-        integrity: sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==,
-      }
-    engines: { node: ">=4" }
 
   deep-is@0.1.4:
     resolution:
@@ -1363,12 +1382,6 @@ packages:
     resolution:
       {
         integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==,
-      }
-
-  end-of-stream@1.4.5:
-    resolution:
-      {
-        integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
       }
 
   enquirer@2.3.6:
@@ -1552,6 +1565,12 @@ packages:
         integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
       }
 
+  events-universal@1.0.1:
+    resolution:
+      {
+        integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==,
+      }
+
   execa@5.1.1:
     resolution:
       {
@@ -1576,6 +1595,12 @@ packages:
     resolution:
       {
         integrity: sha512-NcvQXt7Cky1cNau15FWy64IjuO8X0JijhTBBrJj1YlxlDfRkJXNaK9RFUjwpfDPzMdv7wB38jr53l9tkNLxnWg==,
+      }
+
+  fast-fifo@1.3.2:
+    resolution:
+      {
+        integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==,
       }
 
   fast-glob@3.2.11:
@@ -1623,12 +1648,6 @@ packages:
         integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==,
       }
 
-  fd-slicer@1.1.0:
-    resolution:
-      {
-        integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==,
-      }
-
   fdir@6.5.0:
     resolution:
       {
@@ -1648,26 +1667,12 @@ packages:
       }
     engines: { node: ^10.12.0 || >=12.0.0 }
 
-  file-type@3.9.0:
+  file-type@21.3.4:
     resolution:
       {
-        integrity: sha512-RLoqTXE8/vPmMuTI88DAzhMYC99I8BWv7zYP4A1puo5HIjEJ5EX48ighy4ZyKMG9EDXxBgW6e++cn7d1xuFghA==,
+        integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==,
       }
-    engines: { node: ">=0.10.0" }
-
-  file-type@5.2.0:
-    resolution:
-      {
-        integrity: sha512-Iq1nJ6D2+yIO4c8HHg4fyVb8mAJieo1Oloy1mLLaB2PvezNedhBVm+QU7g0qM42aiMbRXTxKKwGD17rjKNJYVQ==,
-      }
-    engines: { node: ">=4" }
-
-  file-type@6.2.0:
-    resolution:
-      {
-        integrity: sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg==,
-      }
-    engines: { node: ">=4" }
+    engines: { node: ">=20" }
 
   filelist@1.0.4:
     resolution:
@@ -1735,12 +1740,6 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  fs-constants@1.0.0:
-    resolution:
-      {
-        integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==,
-      }
-
   fs-extra@11.3.2:
     resolution:
       {
@@ -1800,19 +1799,19 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  get-stream@2.3.1:
-    resolution:
-      {
-        integrity: sha512-AUGhbbemXxrZJRD5cDvKtQxLuYaIbNtDTK8YqupCI393Q2KSTreEsLUN3ZxAWFGiKTzL6nKuzfcIvieflUX9qA==,
-      }
-    engines: { node: ">=0.10.0" }
-
   get-stream@6.0.1:
     resolution:
       {
         integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==,
       }
     engines: { node: ">=10" }
+
+  get-stream@9.0.1:
+    resolution:
+      {
+        integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==,
+      }
+    engines: { node: ">=18" }
 
   glob-parent@5.1.2:
     resolution:
@@ -1869,6 +1868,12 @@ packages:
     resolution:
       {
         integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==,
+      }
+
+  graceful-fs@4.2.11:
+    resolution:
+      {
+        integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
 
   grapheme-splitter@1.0.4:
@@ -2026,6 +2031,12 @@ packages:
         integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
       }
 
+  inspect-with-kind@1.0.5:
+    resolution:
+      {
+        integrity: sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==,
+      }
+
   interface-datastore@8.3.2:
     resolution:
       {
@@ -2129,18 +2140,19 @@ packages:
       }
     engines: { node: ">=8" }
 
-  is-natural-number@4.0.1:
-    resolution:
-      {
-        integrity: sha512-Y4LTamMe0DDQIIAlaer9eKebAlDSV6huy+TWhJVPlzZh2o4tRP5SQWFlLn5N0To4mDD22/qdOq+veo1cSISLgQ==,
-      }
-
   is-number@7.0.0:
     resolution:
       {
         integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
       }
     engines: { node: ">=0.12.0" }
+
+  is-plain-obj@1.1.0:
+    resolution:
+      {
+        integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==,
+      }
+    engines: { node: ">=0.10.0" }
 
   is-plain-obj@2.1.0:
     resolution:
@@ -2163,19 +2175,19 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  is-stream@1.1.0:
-    resolution:
-      {
-        integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==,
-      }
-    engines: { node: ">=0.10.0" }
-
   is-stream@2.0.1:
     resolution:
       {
         integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==,
       }
     engines: { node: ">=8" }
+
+  is-stream@4.0.1:
+    resolution:
+      {
+        integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==,
+      }
+    engines: { node: ">=18" }
 
   is-typed-array@1.1.15:
     resolution:
@@ -2197,18 +2209,6 @@ packages:
         integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==,
       }
     engines: { node: ">=16" }
-
-  isarray@1.0.0:
-    resolution:
-      {
-        integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==,
-      }
-
-  isarray@2.0.5:
-    resolution:
-      {
-        integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==,
-      }
 
   isexe@2.0.0:
     resolution:
@@ -2314,10 +2314,10 @@ packages:
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     resolution:
       {
-        integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==,
+        integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==,
       }
     hasBin: true
 
@@ -2356,6 +2356,13 @@ packages:
       {
         integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
       }
+
+  kind-of@6.0.3:
+    resolution:
+      {
+        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+      }
+    engines: { node: ">=0.10.0" }
 
   kubo-rpc-client@5.4.1:
     resolution:
@@ -2524,13 +2531,6 @@ packages:
         integrity: sha512-NWtdGrAca/69fm6DIVd8T9rtfDII4Q8NQbIbsKQq2VzS9eqOGYs8uaNQjcuaCq/d9H/o625aOTJX2Qoxzqw0Pw==,
       }
 
-  make-dir@1.3.0:
-    resolution:
-      {
-        integrity: sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==,
-      }
-    engines: { node: ">=4" }
-
   matchstick-as@0.5.0:
     resolution:
       {
@@ -2672,7 +2672,7 @@ packages:
         integrity: sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg==,
       }
     peerDependencies:
-      undici: ^7.24.0
+      undici: ^7.28.0
 
   natural-compare@1.4.0:
     resolution:
@@ -2693,12 +2693,6 @@ packages:
         integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==,
       }
     engines: { node: ">=0.10.0" }
-
-  once@1.4.0:
-    resolution:
-      {
-        integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
-      }
 
   onetime@5.1.2:
     resolution:
@@ -2850,40 +2844,12 @@ packages:
       }
     engines: { node: ">=8.6" }
 
-  picomatch@4.0.4:
+  picomatch@4.0.5:
     resolution:
       {
-        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
+        integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==,
       }
     engines: { node: ">=12" }
-
-  pify@2.3.0:
-    resolution:
-      {
-        integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  pify@3.0.0:
-    resolution:
-      {
-        integrity: sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==,
-      }
-    engines: { node: ">=4" }
-
-  pinkie-promise@2.0.1:
-    resolution:
-      {
-        integrity: sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==,
-      }
-    engines: { node: ">=0.10.0" }
-
-  pinkie@2.0.4:
-    resolution:
-      {
-        integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==,
-      }
-    engines: { node: ">=0.10.0" }
 
   pluralize@8.0.0:
     resolution:
@@ -2921,12 +2887,6 @@ packages:
       }
     engines: { node: ">=14" }
     hasBin: true
-
-  process-nextick-args@2.0.1:
-    resolution:
-      {
-        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
-      }
 
   progress-events@1.1.0:
     resolution:
@@ -2983,12 +2943,6 @@ packages:
     resolution:
       {
         integrity: sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==,
-      }
-
-  readable-stream@2.3.8:
-    resolution:
-      {
-        integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==,
       }
 
   readable-stream@3.6.0:
@@ -3069,12 +3023,6 @@ packages:
         integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==,
       }
 
-  safe-buffer@5.1.2:
-    resolution:
-      {
-        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
-      }
-
   safe-buffer@5.2.1:
     resolution:
       {
@@ -3094,10 +3042,10 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  seek-bzip@1.0.6:
+  seek-bzip@2.0.0:
     resolution:
       {
-        integrity: sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==,
+        integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==,
       }
     hasBin: true
 
@@ -3181,18 +3129,18 @@ packages:
         integrity: sha512-AqHYAYPHcmvMrcLNgncE/q0Aj/ajP6A4qGhxP6EVn7K3YTNs0bJpJyk57wc2Heb7MUL64jurvmnmui8D9kjZgA==,
       }
 
+  streamx@2.28.0:
+    resolution:
+      {
+        integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==,
+      }
+
   string-width@4.2.3:
     resolution:
       {
         integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==,
       }
     engines: { node: ">=8" }
-
-  string_decoder@1.1.1:
-    resolution:
-      {
-        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
-      }
 
   string_decoder@1.3.0:
     resolution:
@@ -3214,10 +3162,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  strip-dirs@2.1.0:
+  strip-dirs@3.0.0:
     resolution:
       {
-        integrity: sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==,
+        integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==,
       }
 
   strip-final-newline@2.0.0:
@@ -3233,6 +3181,13 @@ packages:
         integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
       }
     engines: { node: ">=8" }
+
+  strtok3@10.3.5:
+    resolution:
+      {
+        integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==,
+      }
+    engines: { node: ">=18" }
 
   supports-color@10.2.2:
     resolution:
@@ -3262,12 +3217,17 @@ packages:
       }
     engines: { node: ">=10" }
 
-  tar-stream@1.6.2:
+  tar-stream@3.1.7:
     resolution:
       {
-        integrity: sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==,
+        integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==,
       }
-    engines: { node: ">= 0.8.0" }
+
+  text-decoder@1.2.7:
+    resolution:
+      {
+        integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==,
+      }
 
   text-table@0.2.0:
     resolution:
@@ -3301,19 +3261,19 @@ packages:
       }
     engines: { node: ">=14.14" }
 
-  to-buffer@1.2.2:
-    resolution:
-      {
-        integrity: sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==,
-      }
-    engines: { node: ">= 0.4" }
-
   to-regex-range@5.0.1:
     resolution:
       {
         integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
       }
     engines: { node: ">=8.0" }
+
+  token-types@6.1.2:
+    resolution:
+      {
+        integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==,
+      }
+    engines: { node: ">=14.16" }
 
   tslib@1.14.1:
     resolution:
@@ -3363,13 +3323,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  typed-array-buffer@1.0.3:
-    resolution:
-      {
-        integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==,
-      }
-    engines: { node: ">= 0.4" }
-
   typescript@4.7.4:
     resolution:
       {
@@ -3383,6 +3336,13 @@ packages:
       {
         integrity: sha512-FwpTa7ZGA/f/EssWAb5/YV6pHgVF1fViKdW8cWaEarjB8t7NyofSWBdOTyFPaGuUG4gx3v1O3PQ8etsiOs3lcw==,
       }
+
+  uint8array-extras@1.5.0:
+    resolution:
+      {
+        integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==,
+      }
+    engines: { node: ">=18" }
 
   uint8arraylist@2.4.8:
     resolution:
@@ -3402,10 +3362,10 @@ packages:
         integrity: sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==,
       }
 
-  undici@7.25.0:
+  undici@7.28.0:
     resolution:
       {
-        integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==,
+        integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==,
       }
     engines: { node: ">=20.18.1" }
 
@@ -3569,12 +3529,6 @@ packages:
       }
     engines: { node: ">=10" }
 
-  wrappy@1.0.2:
-    resolution:
-      {
-        integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
-      }
-
   ws@7.5.11:
     resolution:
       {
@@ -3597,13 +3551,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  xtend@4.0.2:
-    resolution:
-      {
-        integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==,
-      }
-    engines: { node: ">=0.4" }
-
   yaml@2.8.3:
     resolution:
       {
@@ -3619,11 +3566,12 @@ packages:
       }
     engines: { node: ">=12" }
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     resolution:
       {
-        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==,
+        integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==,
       }
+    engines: { node: ">=12" }
 
   yocto-queue@0.1.0:
     resolution:
@@ -3658,6 +3606,8 @@ snapshots:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
+  "@borewit/text-codec@0.2.2": {}
+
   "@chainsafe/is-ip@2.1.0": {}
 
   "@chainsafe/netmask@2.0.0":
@@ -3677,7 +3627,7 @@ snapshots:
       globals: 13.17.0
       ignore: 5.2.0
       import-fresh: 3.3.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       minimatch: 5.1.9
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3690,41 +3640,43 @@ snapshots:
       "@rescript/std": 9.0.0
       graphql: 16.11.0
       graphql-import-node: 0.0.5(graphql@16.11.0)
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
 
-  "@graphprotocol/graph-cli@0.98.1(@types/node@20.1.1)(typescript@4.7.4)(zod@3.25.76)":
+  "@graphprotocol/graph-cli@0.98.1(@types/node@20.1.1)(supports-color@8.1.1)(typescript@4.7.4)(zod@3.25.76)":
     dependencies:
       "@float-capital/float-subgraph-uncrashable": 0.0.0-internal-testing.5
       "@oclif/core": 4.5.5
-      "@oclif/plugin-autocomplete": 3.2.43
+      "@oclif/plugin-autocomplete": 3.2.43(supports-color@8.1.1)
       "@oclif/plugin-not-found": 3.2.78(@types/node@20.1.1)
-      "@oclif/plugin-warn-if-update-available": 3.1.58
+      "@oclif/plugin-warn-if-update-available": 3.1.58(supports-color@8.1.1)
       "@pinax/graph-networks-registry": 0.7.1
       "@whatwg-node/fetch": 0.10.13
       assemblyscript: 0.19.23
       chokidar: 4.0.3
       debug: 4.4.3(supports-color@8.1.1)
-      decompress: 4.2.1
+      decompress: "@xhmikosr/decompress@11.1.3"
       docker-compose: 1.3.0
       fs-extra: 11.3.2
       glob: 11.1.0
-      gluegun: 5.2.0(debug@4.4.3)
+      gluegun: 5.2.0(debug@4.4.3(supports-color@8.1.1))
       graphql: 16.11.0
       immutable: 5.1.5
       jayson: 4.2.0
-      js-yaml: 4.2.0
-      kubo-rpc-client: 5.4.1(undici@7.25.0)
+      js-yaml: 4.3.0
+      kubo-rpc-client: 5.4.1(undici@7.28.0)
       open: 10.2.0
       prettier: 3.6.2
       progress: 2.0.3
       semver: 7.7.3
       tmp-promise: 3.0.3
-      undici: 7.25.0
+      undici: 7.28.0
       web3-eth-abi: 4.4.1(typescript@4.7.4)(zod@3.25.76)
       yaml: 2.8.3
     transitivePeerDependencies:
       - "@types/node"
+      - bare-abort-controller
       - bufferutil
+      - react-native-b4a
       - supports-color
       - typescript
       - utf-8-validate
@@ -4034,7 +3986,7 @@ snapshots:
       wordwrap: 1.0.0
       wrap-ansi: 7.0.0
 
-  "@oclif/plugin-autocomplete@3.2.43":
+  "@oclif/plugin-autocomplete@3.2.43(supports-color@8.1.1)":
     dependencies:
       "@oclif/core": 4.10.3
       ansis: 3.17.0
@@ -4052,12 +4004,12 @@ snapshots:
     transitivePeerDependencies:
       - "@types/node"
 
-  "@oclif/plugin-warn-if-update-available@3.1.58":
+  "@oclif/plugin-warn-if-update-available@3.1.58(supports-color@8.1.1)":
     dependencies:
       "@oclif/core": 4.10.3
       ansis: 3.17.0
       debug: 4.4.3(supports-color@8.1.1)
-      http-call: 5.3.0
+      http-call: 5.3.0(supports-color@8.1.1)
       lodash: 4.18.1
       registry-auth-token: 5.1.1
     transitivePeerDependencies:
@@ -4091,6 +4043,17 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.4.0
       "@scure/base": 1.1.9
+
+  "@sec-ant/readable-stream@0.4.1": {}
+
+  "@tokenizer/inflate@0.4.1":
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  "@tokenizer/token@0.3.0": {}
 
   "@types/connect@3.4.35":
     dependencies:
@@ -4209,6 +4172,59 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  "@xhmikosr/decompress-tar@9.0.1":
+    dependencies:
+      file-type: 21.3.4
+      is-stream: 4.0.1
+      tar-stream: 3.1.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
+  "@xhmikosr/decompress-tarbz2@9.0.2":
+    dependencies:
+      "@xhmikosr/decompress-tar": 9.0.1
+      file-type: 21.3.4
+      is-stream: 4.0.1
+      seek-bzip: 2.0.0
+      unbzip2-stream: 1.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
+  "@xhmikosr/decompress-targz@9.0.1":
+    dependencies:
+      "@xhmikosr/decompress-tar": 9.0.1
+      file-type: 21.3.4
+      is-stream: 4.0.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
+  "@xhmikosr/decompress-unzip@8.2.1":
+    dependencies:
+      file-type: 21.3.4
+      get-stream: 9.0.1
+      yauzl: 3.4.0
+    transitivePeerDependencies:
+      - supports-color
+
+  "@xhmikosr/decompress@11.1.3":
+    dependencies:
+      "@xhmikosr/decompress-tar": 9.0.1
+      "@xhmikosr/decompress-tarbz2": 9.0.2
+      "@xhmikosr/decompress-targz": 9.0.1
+      "@xhmikosr/decompress-unzip": 8.2.1
+      graceful-fs: 4.2.11
+      strip-dirs: 3.0.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+      - supports-color
+
   abitype@0.7.1(typescript@4.7.4)(zod@3.25.76):
     dependencies:
       typescript: 4.7.4
@@ -4252,9 +4268,9 @@ snapshots:
 
   any-signal@4.2.0: {}
 
-  apisauce@2.1.6(debug@4.4.3):
+  apisauce@2.1.6(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      axios: 1.16.0(debug@4.4.3)
+      axios: 1.16.0(debug@4.4.3(supports-color@8.1.1))
     transitivePeerDependencies:
       - debug
 
@@ -4285,28 +4301,27 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.16.0(debug@4.4.3):
+  axios@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.16.0(debug@4.4.3)
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       form-data: 4.0.6
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
 
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
 
   base64-js@1.5.1: {}
 
   binaryen@101.0.0-nightly.20210723: {}
 
   binaryen@102.0.0-nightly.20211028: {}
-
-  bl@1.2.3:
-    dependencies:
-      readable-stream: 2.3.8
-      safe-buffer: 5.2.1
 
   blob-to-it@2.0.10:
     dependencies:
@@ -4316,7 +4331,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4325,17 +4340,6 @@ snapshots:
       fill-range: 7.1.1
 
   browser-readablestream-to-it@2.0.10: {}
-
-  buffer-alloc-unsafe@1.1.0: {}
-
-  buffer-alloc@1.2.0:
-    dependencies:
-      buffer-alloc-unsafe: 1.1.0
-      buffer-fill: 1.0.0
-
-  buffer-crc32@0.2.13: {}
-
-  buffer-fill@1.0.0: {}
 
   buffer-from@1.1.2: {}
 
@@ -4432,14 +4436,14 @@ snapshots:
 
   commander@2.20.3: {}
 
+  commander@6.2.1: {}
+
   config-chain@1.1.13:
     dependencies:
       ini: 1.3.8
       proto-list: 1.2.4
 
   content-type@1.0.5: {}
-
-  core-util-is@1.0.3: {}
 
   cosmiconfig@7.0.1:
     dependencies:
@@ -4469,44 +4473,6 @@ snapshots:
       ms: 2.1.3
     optionalDependencies:
       supports-color: 8.1.1
-
-  decompress-tar@4.1.1:
-    dependencies:
-      file-type: 5.2.0
-      is-stream: 1.1.0
-      tar-stream: 1.6.2
-
-  decompress-tarbz2@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 6.2.0
-      is-stream: 1.1.0
-      seek-bzip: 1.0.6
-      unbzip2-stream: 1.4.3
-
-  decompress-targz@4.1.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      file-type: 5.2.0
-      is-stream: 1.1.0
-
-  decompress-unzip@4.0.1:
-    dependencies:
-      file-type: 3.9.0
-      get-stream: 2.3.1
-      pify: 2.3.0
-      yauzl: 2.10.0
-
-  decompress@4.2.1:
-    dependencies:
-      decompress-tar: 4.1.1
-      decompress-tarbz2: 4.1.1
-      decompress-targz: 4.1.1
-      decompress-unzip: 4.0.1
-      graceful-fs: 4.2.10
-      make-dir: 1.3.0
-      pify: 2.3.0
-      strip-dirs: 2.1.0
 
   deep-is@0.1.4: {}
 
@@ -4565,10 +4531,6 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
-
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
@@ -4592,7 +4554,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.4
+      hasown: 2.0.2
 
   es6-promise@4.2.8: {}
 
@@ -4656,7 +4618,7 @@ snapshots:
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -4700,6 +4662,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4717,6 +4685,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.2.0: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.2.11:
     dependencies:
@@ -4748,23 +4718,22 @@ snapshots:
     dependencies:
       reusify: 1.0.4
 
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
-
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.0.4
 
-  file-type@3.9.0: {}
-
-  file-type@5.2.0: {}
-
-  file-type@6.2.0: {}
+  file-type@21.3.4:
+    dependencies:
+      "@tokenizer/inflate": 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   filelist@1.0.4:
     dependencies:
@@ -4786,7 +4755,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0(debug@4.4.3):
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.4.3(supports-color@8.1.1)
 
@@ -4806,8 +4775,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.4
       mime-types: 2.1.35
-
-  fs-constants@1.0.0: {}
 
   fs-extra@11.3.2:
     dependencies:
@@ -4848,12 +4815,12 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
-  get-stream@2.3.1:
-    dependencies:
-      object-assign: 4.1.1
-      pinkie-promise: 2.0.1
-
   get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      "@sec-ant/readable-stream": 0.4.1
+      is-stream: 4.0.1
 
   glob-parent@5.1.2:
     dependencies:
@@ -4885,9 +4852,9 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  gluegun@5.2.0(debug@4.4.3):
+  gluegun@5.2.0(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
-      apisauce: 2.1.6(debug@4.4.3)
+      apisauce: 2.1.6(debug@4.4.3(supports-color@8.1.1))
       app-module-path: 2.2.0
       cli-table3: 0.6.0
       colors: 1.4.0
@@ -4924,6 +4891,8 @@ snapshots:
 
   graceful-fs@4.2.10: {}
 
+  graceful-fs@4.2.11: {}
+
   grapheme-splitter@1.0.4: {}
 
   graphql-import-node@0.0.5(graphql@16.11.0):
@@ -4956,7 +4925,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  http-call@5.3.0:
+  http-call@5.3.0(supports-color@8.1.1):
     dependencies:
       content-type: 1.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -4995,6 +4964,10 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  inspect-with-kind@1.0.5:
+    dependencies:
+      kind-of: 6.0.3
 
   interface-datastore@8.3.2:
     dependencies:
@@ -5045,9 +5018,9 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-natural-number@4.0.1: {}
-
   is-number@7.0.0: {}
+
+  is-plain-obj@1.1.0: {}
 
   is-plain-obj@2.1.0: {}
 
@@ -5060,9 +5033,9 @@ snapshots:
 
   is-retry-allowed@1.2.0: {}
 
-  is-stream@1.1.0: {}
-
   is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
 
   is-typed-array@1.1.15:
     dependencies:
@@ -5075,10 +5048,6 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
-
-  isarray@1.0.0: {}
-
-  isarray@2.0.5: {}
 
   isexe@2.0.0: {}
 
@@ -5150,7 +5119,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -5168,9 +5137,11 @@ snapshots:
     dependencies:
       universalify: 2.0.0
     optionalDependencies:
-      graceful-fs: 4.2.10
+      graceful-fs: 4.2.11
 
-  kubo-rpc-client@5.4.1(undici@7.25.0):
+  kind-of@6.0.3: {}
+
+  kubo-rpc-client@5.4.1(undici@7.28.0):
     dependencies:
       "@ipld/dag-cbor": 9.2.6
       "@ipld/dag-json": 10.2.7
@@ -5199,7 +5170,7 @@ snapshots:
       merge-options: 3.0.4
       multiformats: 13.4.2
       nanoid: 5.1.7
-      native-fetch: 4.0.2(undici@7.25.0)
+      native-fetch: 4.0.2(undici@7.28.0)
       parse-duration: 2.1.5
       react-native-fetch-api: 3.0.0
       stream-to-it: 1.0.1
@@ -5267,10 +5238,6 @@ snapshots:
 
   main-event@1.0.1: {}
 
-  make-dir@1.3.0:
-    dependencies:
-      pify: 3.0.0
-
   matchstick-as@0.5.0:
     dependencies:
       "@graphprotocol/graph-ts": 0.27.0
@@ -5302,7 +5269,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@5.1.9:
     dependencies:
@@ -5328,9 +5295,9 @@ snapshots:
 
   nanoid@5.1.7: {}
 
-  native-fetch@4.0.2(undici@7.25.0):
+  native-fetch@4.0.2(undici@7.28.0):
     dependencies:
-      undici: 7.25.0
+      undici: 7.28.0
 
   natural-compare@1.4.0: {}
 
@@ -5339,10 +5306,6 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -5433,17 +5396,7 @@ snapshots:
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.4: {}
-
-  pify@2.3.0: {}
-
-  pify@3.0.0: {}
-
-  pinkie-promise@2.0.1:
-    dependencies:
-      pinkie: 2.0.4
-
-  pinkie@2.0.4: {}
+  picomatch@4.0.5: {}
 
   pluralize@8.0.0: {}
 
@@ -5454,8 +5407,6 @@ snapshots:
   prettier@2.7.1: {}
 
   prettier@3.6.2: {}
-
-  process-nextick-args@2.0.1: {}
 
   progress-events@1.1.0: {}
 
@@ -5484,16 +5435,6 @@ snapshots:
   react-native-fetch-api@3.0.0:
     dependencies:
       p-defer: 3.0.0
-
-  readable-stream@2.3.8:
-    dependencies:
-      core-util-is: 1.0.3
-      inherits: 2.0.4
-      isarray: 1.0.0
-      process-nextick-args: 2.0.1
-      safe-buffer: 5.1.2
-      string_decoder: 1.1.1
-      util-deprecate: 1.0.2
 
   readable-stream@3.6.0:
     dependencies:
@@ -5532,8 +5473,6 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  safe-buffer@5.1.2: {}
-
   safe-buffer@5.2.1: {}
 
   safe-regex-test@1.1.0:
@@ -5544,9 +5483,9 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  seek-bzip@1.0.6:
+  seek-bzip@2.0.0:
     dependencies:
-      commander: 2.20.3
+      commander: 6.2.1
 
   semver@7.7.3: {}
 
@@ -5588,15 +5527,20 @@ snapshots:
     dependencies:
       it-stream-types: 2.0.2
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-
-  string_decoder@1.1.1:
-    dependencies:
-      safe-buffer: 5.1.2
 
   string_decoder@1.3.0:
     dependencies:
@@ -5610,13 +5554,18 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-dirs@2.1.0:
+  strip-dirs@3.0.0:
     dependencies:
-      is-natural-number: 4.0.1
+      inspect-with-kind: 1.0.5
+      is-plain-obj: 1.1.0
 
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  strtok3@10.3.5:
+    dependencies:
+      "@tokenizer/token": 0.3.0
 
   supports-color@10.2.2: {}
 
@@ -5632,15 +5581,20 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  tar-stream@1.6.2:
+  tar-stream@3.1.7:
     dependencies:
-      bl: 1.2.3
-      buffer-alloc: 1.2.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      readable-stream: 2.3.8
-      to-buffer: 1.2.2
-      xtend: 4.0.2
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   text-table@0.2.0: {}
 
@@ -5648,8 +5602,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tmp-promise@3.0.3:
     dependencies:
@@ -5657,15 +5611,15 @@ snapshots:
 
   tmp@0.2.7: {}
 
-  to-buffer@1.2.2:
-    dependencies:
-      isarray: 2.0.5
-      safe-buffer: 5.2.1
-      typed-array-buffer: 1.0.3
-
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  token-types@6.1.2:
+    dependencies:
+      "@borewit/text-codec": 0.2.2
+      "@tokenizer/token": 0.3.0
+      ieee754: 1.2.1
 
   tslib@1.14.1: {}
 
@@ -5688,18 +5642,14 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  typed-array-buffer@1.0.3:
-    dependencies:
-      call-bound: 1.0.4
-      es-errors: 1.3.0
-      is-typed-array: 1.1.15
-
   typescript@4.7.4: {}
 
   uint8-varint@2.0.4:
     dependencies:
       uint8arraylist: 2.4.8
       uint8arrays: 5.1.0
+
+  uint8array-extras@1.5.0: {}
 
   uint8arraylist@2.4.8:
     dependencies:
@@ -5714,7 +5664,7 @@ snapshots:
       buffer: 5.7.1
       through: 2.3.8
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   universalify@2.0.0: {}
 
@@ -5822,24 +5772,19 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrappy@1.0.2: {}
-
   ws@7.5.11: {}
 
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
 
-  xtend@4.0.2: {}
-
   yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,12 @@ blockExoticSubdeps: true
 engineStrict: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
-  - "axios@1.16.0"
   - "form-data@4.0.6"
 allowBuilds: {}
 overrides:
   "ajv@<6.14.0": "^6.14.0"
-  "axios@<1.15.2": "^1.15.2"
-  "brace-expansion@<2.0.3": "^2.0.3"
+  "axios@<1.18.0": "^1.18.0"
+  "brace-expansion@<2.1.2": "^2.1.2"
   "braces@<3.0.3": "^3.0.3"
   "cross-spawn@<7.0.5": "^7.0.5"
   "@graphprotocol/graph-cli>decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
@@ -17,7 +16,7 @@ overrides:
   "follow-redirects@<1.16.0": "^1.16.0"
   "form-data@>=4.0.0 <4.0.6": "^4.0.6"
   "glob@<11.1.0": "^11.1.0"
-  "immutable@<5.1.5": "^5.1.5"
+  "immutable@<5.1.8": "^5.1.8"
   "js-yaml@<=4.1.1": "^4.2.0"
   "lodash.trim@<4.18.0": "4.18.0"
   "lodash.trimend@<4.18.0": "4.18.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "axios@1.16.0"
   - "form-data@4.0.6"
-onlyBuiltDependencies: []
+allowBuilds: {}
 overrides:
   "ajv@<6.14.0": "^6.14.0"
   "axios@<1.15.2": "^1.15.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,17 +1,17 @@
+blockExoticSubdeps: true
+engineStrict: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - "axios@1.16.0"
   - "form-data@4.0.6"
-preferFrozenLockfile: true
-engineStrict: true
-strictDepBuilds: true
-blockExoticSubdeps: true
+onlyBuiltDependencies: []
 overrides:
   "ajv@<6.14.0": "^6.14.0"
   "axios@<1.15.2": "^1.15.2"
   "brace-expansion@<2.0.3": "^2.0.3"
   "braces@<3.0.3": "^3.0.3"
   "cross-spawn@<7.0.5": "^7.0.5"
+  "decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
   "ejs@<3.1.10": "^3.1.10"
   "flatted@<3.4.2": "^3.4.2"
   "follow-redirects@<1.16.0": "^1.16.0"
@@ -29,8 +29,10 @@ overrides:
   "picomatch@<2.3.2": "^2.3.2"
   "semver@<7.5.2": "^7.5.2"
   "tmp@<0.2.6": "^0.2.6"
-  "undici@<7.24.0": "^7.24.0"
+  "undici@>=7.0.0 <7.28.0": "^7.28.0"
   "uuid@<11.1.1": "^11.1.1"
   "ws@>=7.0.0 <7.5.11": "^7.5.11"
   "word-wrap@<1.2.4": "^1.2.4"
   "yaml@<2.8.3": "^2.8.3"
+preferFrozenLockfile: true
+strictDepBuilds: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ overrides:
   "brace-expansion@<2.0.3": "^2.0.3"
   "braces@<3.0.3": "^3.0.3"
   "cross-spawn@<7.0.5": "^7.0.5"
-  "decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
+  "@graphprotocol/graph-cli>decompress@<=4.2.1": "npm:@xhmikosr/decompress@^11.1.3"
   "ejs@<3.1.10": "^3.1.10"
   "flatted@<3.4.2": "^3.4.2"
   "follow-redirects@<1.16.0": "^1.16.0"


### PR DESCRIPTION
## Summary

The Graph CLI archive path no longer resolves to the unmaintained `decompress` package affected by critical path-traversal advisory `GHSA-mp2f-45pm-3cg9`; it now uses the compatible maintained fork. The repository is also aligned with pnpm 11 security policy, current moderate-or-higher dependency findings are remediated with bounded overrides, and CI checkout credentials and write permissions are narrowed.

## Validation

- `pnpm install --no-frozen-lockfile`
- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` — no known vulnerabilities
- `pnpm run build`
- `pnpm run lint:check` — 0 errors; existing generated-code warnings remain
- Graph CLI archive module compatibility load

The repository contains no test files or container build targets, so those checks were not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened CI and audit workflows by preventing credentials from being persisted after checkout.
  * Tightened workflow permissions by moving to job-scoped authorization with read-only contents access.
* **Chores**
  * Updated required pnpm tooling to **11.13.0** and refreshed package manager metadata.
  * Refined workspace dependency/version constraints and lockfile/build strictness to improve installation consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->